### PR TITLE
[scripts]: add wingsv:// link generator

### DIFF
--- a/scripts/gen_wingsv_link/README.md
+++ b/scripts/gen_wingsv_link/README.md
@@ -1,0 +1,57 @@
+# gen_wingsv_link
+
+Генерация `wingsv://` ссылок для импорта конфигурации в WINGS V.
+
+Ссылки кодируют конфигурацию VK TURN + WireGuard через protobuf + zlib + base64url — тот же формат, что использует встроенный импорт/экспорт приложения.
+
+## Зависимости
+
+```bash
+pip install -r requirements.txt
+```
+
+- **protobuf** — сериализация protobuf-сообщений
+- **grpcio-tools** — встроенный Python-компилятор protobuf (системный `protoc` не нужен)
+
+Если `grpcio-tools` не установлен, скрипт использует системный `protoc` как фоллбэк.
+
+## Использование
+
+```bash
+python3 scripts/gen_wingsv_link/gen_wingsv_link.py \
+  --server 1.2.3.4:56000 \
+  --vk-link "https://vk.com/call/join/..." \
+  --wg-privkey "приватный_ключ_base64=" \
+  --wg-address "10.0.0.2/32" \
+  --wg-peer-pubkey "публичный_ключ_base64="
+```
+
+На выходе — `wingsv://` ссылка для импорта в WINGS V через буфер обмена или intent.
+
+## Параметры
+
+| Параметр | Обязательный | По умолчанию | Описание |
+|----------|:------------:|:------------:|----------|
+| `--server` | да | — | VK TURN прокси-сервер `host:port` |
+| `--vk-link` | да | — | Ссылка на VK-звонок |
+| `--wg-privkey` | да | — | Приватный ключ WireGuard (base64) |
+| `--wg-address` | да | — | Адрес интерфейса WireGuard (CIDR) |
+| `--wg-peer-pubkey` | да | — | Публичный ключ peer WireGuard (base64) |
+| `--wg-dns` | нет | `1.1.1.1` | DNS-сервер |
+| `--threads` | нет | `4` | Количество параллельных TURN-потоков |
+| `--proto-path` | нет | авто | Путь к `wingsv.proto` |
+
+## Автоопределение proto
+
+Скрипт автоматически находит `app/src/main/proto/wingsv.proto` относительно своего расположения в репозитории — поднимается вверх по дереву каталогов до корня (маркер: `settings.gradle.kts`). Для ручного указания используйте `--proto-path`.
+
+## Формат ссылки
+
+```
+wingsv://{base64url(0x12 + zlib(protobuf))}
+```
+
+- `0x12` — маркер формата (`FORMAT_PROTOBUF_DEFLATE`)
+- zlib — RFC 1950 (с заголовком), совместим с Java `Deflater()`/`Inflater()` по умолчанию
+- protobuf — сообщение `Config` из `wingsv.proto`
+- base64url — RFC 4648 §5, без паддинга

--- a/scripts/gen_wingsv_link/gen_wingsv_link.py
+++ b/scripts/gen_wingsv_link/gen_wingsv_link.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Генерация wingsv:// ссылок для импорта в WINGS V Android.
+
+Формат: wingsv://{base64url(0x12 + zlib(protobuf))}
+
+Схема protobuf: app/src/main/proto/wingsv.proto
+Репозиторий: https://github.com/WINGS-N/WINGSV
+
+Использование:
+    python3 gen_wingsv_link.py \\
+        --server 1.2.3.4:56000 \\
+        --vk-link "https://vk.com/call/join/..." \\
+        --wg-privkey "base64key=" \\
+        --wg-address "192.168.24.50/32" \\
+        --wg-peer-pubkey "base64key="
+
+Зависимости:
+    pip install protobuf grpcio-tools
+"""
+
+import argparse
+import base64
+import importlib
+import subprocess
+import sys
+import tempfile
+import zlib
+from pathlib import Path
+from types import ModuleType
+        
+from grpc_tools import protoc as grpc_protoc
+
+
+FORMAT_PROTOBUF_DEFLATE = 0x12
+CURRENT_VERSION = 1
+
+_DEFAULT_PROTO_REL = Path("app", "src", "main", "proto", "wingsv.proto")
+
+
+def _find_proto(explicit_path: str | None) -> Path:
+    """Определяет расположение wingsv.proto.
+
+    Без явного пути ищет вверх по дереву каталогов от расположения скрипта
+    до корня репозитория (ищет settings.gradle.kts как маркер).
+    """
+    if explicit_path:
+        p = Path(explicit_path)
+        if not p.is_file():
+            msg = f"Proto-файл не найден: {p}"
+            raise FileNotFoundError(msg)
+        return p
+
+    cur = Path(__file__).resolve().parent
+    for _ in range(6):
+        candidate = cur / _DEFAULT_PROTO_REL
+        if candidate.is_file():
+            return candidate
+        if (cur / "settings.gradle.kts").is_file():
+            break
+        cur = cur.parent
+
+    script_dir = Path(__file__).resolve().parent
+    msg = (
+        f"Не удалось найти wingsv.proto. Поиск от {script_dir}. "
+        "Используйте --proto-path для указания пути."
+    )
+    raise FileNotFoundError(msg)
+
+
+def _compile_proto(proto_path: Path) -> str:
+    """Компилирует .proto в _pb2.py модуль, возвращает имя модуля."""
+    proto_dir = str(proto_path.parent)
+    proto_name = proto_path.stem
+    out_dir = tempfile.mkdtemp(prefix="wingsv_proto_")
+    out_file = Path(out_dir) / f"{proto_name}_pb2.py"
+
+    # grpcio-tools: встроенный protoc на Python, системный protoc не нужен
+    try:
+
+        result = grpc_protoc.main(
+            [
+                "grpc_tools.protoc",
+                f"--proto_path={proto_dir}",
+                f"--python_out={out_dir}",
+                proto_path.name,
+            ]
+        )
+        if result != 0:
+            msg = f"grpc_tools.protoc завершился с кодом {result}"
+            raise RuntimeError(msg)
+    except ImportError:
+        # Фоллбэк на системный protoc
+        proc = subprocess.run(
+            [
+                "protoc",
+                f"--proto_path={proto_dir}",
+                f"--python_out={out_dir}",
+                proto_path.name,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            msg = (
+                f"protoc завершился с ошибкой: {proc.stderr}\n"
+                "Установите grpcio-tools (pip install grpcio-tools) "
+                "или системный protoc."
+            )
+            raise RuntimeError(msg)
+
+    if not out_file.is_file():
+        msg = f"Скомпилированный proto не найден: {out_file}"
+        raise RuntimeError(msg)
+
+    sys.path.insert(0, out_dir)
+    return f"{proto_name}_pb2"
+
+
+def _load_proto(proto_path: Path) -> ModuleType:
+    """Загружает скомпилированный protobuf-модуль."""
+    return importlib.import_module(_compile_proto(proto_path))
+
+
+def encode_wingsv_link(config: object) -> str:
+    """Кодирует protobuf Config в wingsv:// ссылку.
+
+    Формат: 0x12 (маркер) + zlib (RFC 1950, с заголовком) + base64url без паддинга.
+    zlib-формат совместим с Java Deflater()/Inflater() по умолчанию.
+    """
+    protobuf_payload = config.SerializeToString()
+    compressed = zlib.compress(protobuf_payload, zlib.Z_BEST_COMPRESSION)
+    framed = bytes([FORMAT_PROTOBUF_DEFLATE]) + compressed
+    encoded = base64.urlsafe_b64encode(framed).decode("ascii").rstrip("=")
+    return f"wingsv://{encoded}"
+
+
+def generate(
+    pb: ModuleType,
+    *,
+    server_host: str,
+    server_port: int,
+    vk_link: str,
+    wg_private_key: str,
+    wg_address: str,
+    wg_peer_pubkey: str,
+    wg_dns: str = "1.1.1.1",
+    threads: int = 4,
+) -> str:
+    """Собирает wingsv:// ссылку для конфигурации VK TURN + WireGuard."""
+    config = pb.Config()
+    config.ver = CURRENT_VERSION
+    config.type = pb.CONFIG_TYPE_VK
+    config.backend = pb.BACKEND_TYPE_VK_TURN_WIREGUARD
+
+    config.turn.endpoint.host = server_host
+    config.turn.endpoint.port = server_port
+    config.turn.link = vk_link
+    config.turn.threads = threads
+
+    config.wg.iface.private_key = base64.b64decode(wg_private_key)
+    config.wg.iface.addrs.append(wg_address)
+    config.wg.iface.dns.append(wg_dns)
+    config.wg.peer.public_key = base64.b64decode(wg_peer_pubkey)
+
+    return encode_wingsv_link(config)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Генерация wingsv:// ссылки для импорта в WINGS V",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Пример:\n"
+            '  %(prog)s --server 1.2.3.4:56000 --vk-link "https://vk.com/call/join/..." \\\n'
+            '    --wg-privkey "key=" --wg-address 10.0.0.2/32 --wg-peer-pubkey "key="'
+        ),
+    )
+    parser.add_argument("--server", required=True, help="VK TURN сервер host:port")
+    parser.add_argument("--vk-link", required=True, help="Ссылка на VK-звонок")
+    parser.add_argument(
+        "--wg-privkey", required=True, help="Приватный ключ WireGuard (base64)"
+    )
+    parser.add_argument("--wg-address", required=True, help="Адрес WireGuard (CIDR)")
+    parser.add_argument(
+        "--wg-peer-pubkey", required=True, help="Публичный ключ peer WireGuard (base64)"
+    )
+    parser.add_argument(
+        "--wg-dns", default="1.1.1.1", help="DNS-сервер (по умолчанию: 1.1.1.1)"
+    )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=4,
+        help="Количество TURN-потоков (по умолчанию: 4)",
+    )
+    parser.add_argument(
+        "--proto-path",
+        default=None,
+        help="Путь к wingsv.proto (по умолчанию: автоопределение)",
+    )
+
+    args = parser.parse_args()
+    host, port = args.server.rsplit(":", 1)
+
+    proto_path = _find_proto(args.proto_path)
+    pb = _load_proto(proto_path)
+
+    link = generate(
+        pb,
+        server_host=host,
+        server_port=int(port),
+        vk_link=args.vk_link,
+        wg_private_key=args.wg_privkey,
+        wg_address=args.wg_address,
+        wg_peer_pubkey=args.wg_peer_pubkey,
+        wg_dns=args.wg_dns,
+        threads=args.threads,
+    )
+    print(link)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_wingsv_link/requirements.txt
+++ b/scripts/gen_wingsv_link/requirements.txt
@@ -1,0 +1,2 @@
+protobuf>=5.0
+grpcio-tools>=1.60


### PR DESCRIPTION
## Summary

Скрипт на Python для генерации `wingsv://` ссылок импорта конфигурации VK TURN + WireGuard.

Кодирует protobuf `Config` через zlib + base64url — тот же формат, что использует встроенный импорт/экспорт приложения.

### Возможности

- Автоопределение `wingsv.proto` относительно расположения скрипта в репозитории
- Компиляция protobuf через `grpcio-tools` (системный `protoc` не нужен)
- Фоллбэк на системный `protoc` если `grpcio-tools` не установлен
- Все параметры через CLI-аргументы

### Использование

```bash
pip install protobuf grpcio-tools

python3 scripts/gen_wingsv_link/gen_wingsv_link.py \
  --server 1.2.3.4:56000 \
  --vk-link "https://vk.com/call/join/..." \
  --wg-privkey "key=" \
  --wg-address "10.0.0.2/32" \
  --wg-peer-pubkey "key="
```

### Файлы

- `scripts/gen_wingsv_link/gen_wingsv_link.py` — скрипт
- `scripts/gen_wingsv_link/README.md` — документация
- `scripts/gen_wingsv_link/requirements.txt` — зависимости

### Формат ссылки

```
wingsv://{base64url(0x12 + zlib(protobuf))}
```

Где zlib — RFC 1950 (с заголовком), совместим с Java `Deflater()`/`Inflater()` по умолчанию.