### PR TITLE
[app]: add scrollable first launch screens

### DIFF
--- a/app/src/main/res/layout/fragment_first_launch_connection.xml
+++ b/app/src/main/res/layout/fragment_first_launch_connection.xml
@@ -26,12 +26,17 @@
         android:textColor="#FF16324C"
         android:textStyle="bold" />
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:paddingTop="18dp">
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingTop="18dp">
 
         <TextView
             android:id="@+id/text_first_launch_connection_title"
@@ -123,4 +128,6 @@
                 android:textStyle="bold" />
         </LinearLayout>
     </LinearLayout>
+
+    </ScrollView>
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_first_launch_permissions.xml
+++ b/app/src/main/res/layout/fragment_first_launch_permissions.xml
@@ -7,10 +7,15 @@
     android:paddingEnd="24dp"
     android:paddingBottom="24dp">
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -88,6 +93,8 @@
             android:text="@string/first_launch_continue"
             android:textColor="#FF010102"
             android:textStyle="bold" />
-    </LinearLayout>
+        </LinearLayout>
+
+    </ScrollView>
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_first_launch_vk_turn.xml
+++ b/app/src/main/res/layout/fragment_first_launch_vk_turn.xml
@@ -7,10 +7,15 @@
     android:paddingEnd="24dp"
     android:paddingBottom="24dp">
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
         <TextView
             android:id="@+id/text_vk_turn_title"
@@ -87,5 +92,7 @@
             android:text="@string/continue_label"
             android:textColor="#FF010102"
             android:textStyle="bold" />
-    </LinearLayout>
+        </LinearLayout>
+
+    </ScrollView>
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_first_launch_xray.xml
+++ b/app/src/main/res/layout/fragment_first_launch_xray.xml
@@ -7,10 +7,15 @@
     android:paddingEnd="24dp"
     android:paddingBottom="24dp">
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
         <TextView
             android:id="@+id/text_xray_title"
@@ -101,5 +106,7 @@
             android:text="@string/continue_label"
             android:textColor="#FF010102"
             android:textStyle="bold" />
-    </LinearLayout>
+        </LinearLayout>
+
+    </ScrollView>
 </FrameLayout>


### PR DESCRIPTION
https://github.com/WINGS-N/WINGSV/issues/39
Исправлена проблема с отображением кнопок на экранах первого запуска при больших масштабах дисплея. Добавлены ScrollView с fillViewport=true для всех фрагментов первого запуска, чтобы пользователи могли прокрутить контент и увидеть все элементы управления.

P.S я чуть запутался